### PR TITLE
Add Docker support

### DIFF
--- a/docker/LKH/Dockerfile
+++ b/docker/LKH/Dockerfile
@@ -1,0 +1,12 @@
+from ubuntu:latest
+
+RUN apt-get -y update
+RUN apt-get -y install curl make gcc git python
+RUN curl -LO http://www.akira.ruc.dk/~keld/research/LKH/LKH-2.0.7.tgz
+RUN tar zxf LKH-2.0.7.tgz
+RUN cd LKH-2.0.7 && make && cp ./LKH /usr/local/bin/
+
+RUN git clone https://github.com/superpermutators/superperm.git superperm
+
+RUN echo "cd superperm && /usr/bin/python /superperm/bin/lkh_runner.py -o /mnt/out" > run.sh
+RUN chmod +x run.sh

--- a/docker/LKH/aliases
+++ b/docker/LKH/aliases
@@ -1,0 +1,1 @@
+function lkh-six { docker run --rm -it -v ${1:-$PWD}:/mnt/out lkh /bin/bash run.sh; }

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Docker Images
+
+## Suggested Usage
+
+- **Build the docker image.**
+
+```shell
+cd LKH
+docker build -t lkh .
+```
+
+- **Source the alias file to make life easier.**
+
+```shell
+source aliases
+```
+
+- **Run `lkh-six` to begin the equivalent of `bin/lkh_runner.py -o lkh/out/1/`.**
+
+```shell
+lkh-six $PWD/lkh-six-out/1
+```
+
+You can run as many of these as you like; just change the output directory to avoid conflicts. Hit <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the process.


### PR DESCRIPTION
This PR adds Docker support so that all you need to do to spin up a working _Hunt For LKH(6)_ is:

```shell
lkh-six $PWD/my_output_directory
```

I've added further installation steps in the readme in the `docker/` directory.

You can run several of these at the same time, just like the regular LKH executable.

Would love to hear thoughts on use-cases and how best to serve the community! I wrote this in a few minutes and I'm hoping to add a Concorde image soon as well.

**[EDIT]** The readme I reference above is [here](https://github.com/j6k4m8/superperm/blob/bf719eaaddc3ae3113ca1d575caaf3368a6ae3ce/docker/README.md). Happy to add more documentation if this isn't explanatory enough!