### PR TITLE
Add code to generate supernecklaces and -bracelets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ tsp/%.tsp: atsp/%.atsp
 
 atsp/%.atsp:
 	bin/mkatsp.py $* > "$@"
+
+necklace/%.gtsp:
+	bin/mkatsp.py --necklace $* > "$@"
+
+bracelet/%.gtsp:
+	bin/mkatsp.py --bracelet $* > "$@"

--- a/README.md
+++ b/README.md
@@ -106,3 +106,6 @@ concorde -o "$SUPERPERM_DIR"/concorde/out/6.out "$SUPERPERM_DIR"/tsp/6.tsp
 * The directory `superpermutations` contains various known superpermutations that are interesting for some reason.
 
 * Want to see what's in the superpermutations? Check out the `demutator` directory. (Be wary of the C code.)
+
+* To search for "supernecklaces" and "superbracelets" (strings which contain
+  each permutation only up to rotation and/or reflection), run `make necklace/6.gtsp` or `make bracelet/6.gtsp`. The resulting input files can be solved using the GLKH solver, available from http://webhotel4.ruc.dk/~keld/research/GLKH/ .


### PR DESCRIPTION
A necklace is an equivalence class of strings under rotation; a bracelet is an equivalence class of strings under rotation and reflection. Restricting our attention further to necklaces/bracelets without
repetitions, we can search for "supernecklaces" and "superbracelets", which are strings that contain some representative of each non-repeating necklace/bracelet as a substring (equivalently, strings
which, for every permutation p, contain a substring that may be rotated and/or reflected to obtain p).

This is not a classic TSP, but it can be framed as an Equality-Generalised Travelling Salesman Problem, which can then be converted into an ATSP and solved by the GLKH solver, http://webhotel4.ruc.dk/~keld/research/GLKH/.

This work was inspired by Matthew Clarke's questions on the forum: https://groups.google.com/forum/?#!msg/superpermutators/H1_jrq_EO1c/unrp4Gl_GQAJ

I don't think this is quite ready to be merged: I'd like to make it a bit easier to actually run the solver first (I had to hack up the supplied `runGLKH` script).