### PR TITLE
Improve `splitsuperperm.py` script

### DIFF
--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -2,17 +2,13 @@
 # -*- encoding: utf-8 -*-
 from __future__ import division
 
+import argparse
+import math
 import sys
 
 SYMBOLS = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-n_str = sys.argv[1]
-n = int(n_str)
-
-sorted_perm = list(SYMBOLS[:n])
-
-def split_superperm(superperm):
-    perms = set()
+def permutations(n, superperm):
     counts = [0 for i in range(n)]
     duplicates = 0
     for i in range(n):
@@ -20,8 +16,8 @@ def split_superperm(superperm):
         counts[j] += 1
         if counts[j] == 2:
             duplicates += 1
-    if duplicates == 0: perms.add(superperm[0:n])
-    else: print "..."
+    if duplicates == 0: yield superperm[0:n]
+    else: yield "..."
     for i in range(1, len(superperm) - n + 1):
         old_char = superperm[i-1]
         new_char = superperm[i+n-1]
@@ -35,11 +31,26 @@ def split_superperm(superperm):
                 duplicates -= 1
             if counts[new] == 2:
                 duplicates += 1
-        if duplicates == 0: perms.add(superperm[i : i + n])
-    print len(perms)
+        if duplicates == 0: yield superperm[i : i + n]
+        else: yield '...'
+
+def split_superperm(superperm, opts):
+    if opts.count:
+        perms = set(p for p in permutations(opts.n, superperm) if p != '...')
+        perm_count = len(perms)
+        expected = math.factorial(opts.n)
+        print '{}{}'.format(perm_count, '*' if perm_count == expected else '')
+    else:
+        for p in permutations(opts.n, superperm):
+            print p
+
+parser = argparse.ArgumentParser(description='Find permutations in a string')
+parser.add_argument('-c', '--count', action='store_true')
+parser.add_argument('n', type=int)
+opts = parser.parse_args()
 
 if len(sys.argv) > 2:
-    split_superperm(sys.argv[2])
+    split_superperm(sys.argv[2], opts)
 else:
-    split_superperm(sys.stdin.read().strip())
+    split_superperm(sys.stdin.read().strip(), opts)
 

--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -52,12 +52,28 @@ def split_superperm(superperm, opts):
             print p
 
 
+def split_file(file, opts):
+    for line in file:
+        # strip comments
+        if line.find('#') > -1:
+            line = line[:line.find('#')]
+        line = line.strip()
+        if len(line) == 0:
+            continue
+        split_superperm(line, opts)
+
 parser = argparse.ArgumentParser(description='Find permutations in a string')
 parser.add_argument('-c', '--count', action='store_true')
+parser.add_argument('-s', '--string')
+parser.add_argument('file', nargs='*')
 opts = parser.parse_args()
 
-if len(sys.argv) > 1:
-    split_superperm(sys.argv[1], opts)
+if opts.string:
+    split_superperm(opts.string, opts)
+elif len(opts.file) > 0:
+    for f in opts.file:
+        with open(f) as file:
+            split_file(file, opts)
 else:
-    split_superperm(sys.stdin.read().strip(), opts)
+    split_file(sys.stdin, opts)
 

--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -12,6 +12,7 @@ n = int(n_str)
 sorted_perm = list(SYMBOLS[:n])
 
 def split_superperm(superperm):
+    perms = set()
     counts = [0 for i in range(n)]
     duplicates = 0
     for i in range(n):
@@ -19,7 +20,7 @@ def split_superperm(superperm):
         counts[j] += 1
         if counts[j] == 2:
             duplicates += 1
-    if duplicates == 0: print superperm[0:n]
+    if duplicates == 0: perms.add(superperm[0:n])
     else: print "..."
     for i in range(1, len(superperm) - n + 1):
         old_char = superperm[i-1]
@@ -34,8 +35,8 @@ def split_superperm(superperm):
                 duplicates -= 1
             if counts[new] == 2:
                 duplicates += 1
-        if duplicates == 0: print superperm[i : i + n]
-        else: print "..."
+        if duplicates == 0: perms.add(superperm[i : i + n])
+    print len(perms)
 
 if len(sys.argv) > 2:
     split_superperm(sys.argv[2])

--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -12,29 +12,29 @@ n = int(n_str)
 sorted_perm = list(SYMBOLS[:n])
 
 def split_superperm(superperm):
-    counts = {}
-    for i in range(n):
-        counts[sorted_perm[i]] = 0
+    counts = [0 for i in range(n)]
     duplicates = 0
     for i in range(n):
-        counts[superperm[i]] += 1
-        if counts[superperm[i]] > 1:
+        j = SYMBOLS.index(superperm[i])
+        counts[j] += 1
+        if counts[j] == 2:
             duplicates += 1
     if duplicates == 0: print superperm[0:n]
     else: print "..."
     for i in range(1, len(superperm) - n + 1):
         old_char = superperm[i-1]
-        p = superperm[i : i + n]
-        new_char = p[-1]
+        new_char = superperm[i+n-1]
         if old_char != new_char:
-            counts[old_char] -= 1
-            counts[new_char] += 1
-            # permutationness may have changed
-            if counts[old_char] == 1:
+            old = SYMBOLS.index(old_char)
+            new = SYMBOLS.index(new_char)
+            counts[old] -= 1
+            counts[new] += 1
+            # number of duplicates may have changed
+            if counts[old] == 1:
                 duplicates -= 1
-            if counts[new_char] == 2:
+            if counts[new] == 2:
                 duplicates += 1
-        if duplicates == 0: print p
+        if duplicates == 0: print superperm[i : i + n]
         else: print "..."
 
 if len(sys.argv) > 2:

--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -9,15 +9,9 @@ import sys
 SYMBOLS = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 def permutations(n, superperm):
-    counts = [0 for i in range(n)]
+    yield superperm[0:n] # The first length-n substring should be a permutation
+    counts = [1 for i in range(n)]
     duplicates = 0
-    for i in range(n):
-        j = SYMBOLS.index(superperm[i])
-        counts[j] += 1
-        if counts[j] == 2:
-            duplicates += 1
-    if duplicates == 0: yield superperm[0:n]
-    else: yield "..."
     for i in range(1, len(superperm) - n + 1):
         old_char = superperm[i-1]
         new_char = superperm[i+n-1]
@@ -34,23 +28,36 @@ def permutations(n, superperm):
         if duplicates == 0: yield superperm[i : i + n]
         else: yield '...'
 
+
+def infer_n(superperm):
+    """ The first n elements should be a permutation, so we can infer n """
+    seen = set()
+    for i, c in enumerate(superperm):
+        if c in seen:
+            return i
+        else:
+            seen.add(c)
+    return i
+
+
 def split_superperm(superperm, opts):
+    n = infer_n(superperm)
     if opts.count:
-        perms = set(p for p in permutations(opts.n, superperm) if p != '...')
+        perms = set(p for p in permutations(n, superperm) if p != '...')
         perm_count = len(perms)
-        expected = math.factorial(opts.n)
+        expected = math.factorial(n)
         print '{}{}'.format(perm_count, '*' if perm_count == expected else '')
     else:
-        for p in permutations(opts.n, superperm):
+        for p in permutations(n, superperm):
             print p
+
 
 parser = argparse.ArgumentParser(description='Find permutations in a string')
 parser.add_argument('-c', '--count', action='store_true')
-parser.add_argument('n', type=int)
 opts = parser.parse_args()
 
-if len(sys.argv) > 2:
-    split_superperm(sys.argv[2], opts)
+if len(sys.argv) > 1:
+    split_superperm(sys.argv[1], opts)
 else:
     split_superperm(sys.stdin.read().strip(), opts)
 

--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -12,10 +12,29 @@ n = int(n_str)
 sorted_perm = list(SYMBOLS[:n])
 
 def split_superperm(superperm):
-    for i in range(len(superperm) - n + 1):
+    counts = {}
+    for i in range(n):
+        counts[sorted_perm[i]] = 0
+    duplicates = 0
+    for i in range(n):
+        counts[superperm[i]] += 1
+        if counts[superperm[i]] > 1:
+            duplicates += 1
+    if duplicates == 0: print superperm[0:n]
+    else: print "..."
+    for i in range(1, len(superperm) - n + 1):
+        old_char = superperm[i-1]
         p = superperm[i : i + n]
-        s = sorted(p)
-        if s == sorted_perm: print p
+        new_char = p[-1]
+        if old_char != new_char:
+            counts[old_char] -= 1
+            counts[new_char] += 1
+            # permutationness may have changed
+            if counts[old_char] == 1:
+                duplicates -= 1
+            if counts[new_char] == 2:
+                duplicates += 1
+        if duplicates == 0: print p
         else: print "..."
 
 if len(sys.argv) > 2:


### PR DESCRIPTION
 - Use a faster algorithm for splitting the candidate superpermutation into permutations - O(nm) rather than O(m n log(n))
 - Add a `-c` option to output the count of unique permutations rather than a list (also shows whether the candidate is a superpermutation)
 - Infer the value of `n` from the candidate superpermutation rather than requiring it to be passed in as a parameter
 - Implement standard Unix pipe behaviour: if a list of files are given, read lines from those; otherwise read from standard input
 - Add a `-s` option to provide the old behaviour, in which the candidate is passed as a command-line argument

Together, these get the time to validate `superpermutations/9/409113.txt` down from 0.8s to 0.25s on my machine.