### PR TITLE
Store char counts in dictionaries in splitsuperperm.py

### DIFF
--- a/bin/splitsuperperm.py
+++ b/bin/splitsuperperm.py
@@ -10,20 +10,18 @@ SYMBOLS = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 def permutations(n, superperm):
     yield superperm[0:n] # The first length-n substring should be a permutation
-    counts = [1 for i in range(n)]
+    counts = {SYMBOLS[i]: 1 for i in range(n)}
     duplicates = 0
     for i in range(1, len(superperm) - n + 1):
         old_char = superperm[i-1]
         new_char = superperm[i+n-1]
         if old_char != new_char:
-            old = SYMBOLS.index(old_char)
-            new = SYMBOLS.index(new_char)
-            counts[old] -= 1
-            counts[new] += 1
+            counts[old_char] -= 1
+            counts[new_char] += 1
             # number of duplicates may have changed
-            if counts[old] == 1:
+            if counts[old_char] == 1:
                 duplicates -= 1
-            if counts[new] == 2:
+            if counts[new_char] == 2:
                 duplicates += 1
         if duplicates == 0: yield superperm[i : i + n]
         else: yield '...'


### PR DESCRIPTION
Dictionary insertion is O(len(key)), and we're using single-character keys, so this makes the splitting step O(len(candidate)). It also gives a ~10% wallclock speedup on the n=10 palindromic superpermutation.

This reverts 8e73877ef4731c1f58ea2e7865f6f9402f9e2959. Not sure why I thought that commit was a good idea at the time - a belief that arrays were faster than hashes, I guess, and a failure to realise that I'd need to convert characters into array indices.