### PR TITLE
Add a simple Makefile for DistributedChaffinMethod

### DIFF
--- a/DistributedChaffinMethod/Makefile
+++ b/DistributedChaffinMethod/Makefile
@@ -1,0 +1,5 @@
+CFLAGS = -O3
+
+all: DistributedChaffinMethod
+
+.PHONY: all


### PR DESCRIPTION
This means you should be able to build the program on most Mac or Linux systems just by typing “make”.