### PR TITLE
Add libcurl support and batch file to run on Windows

### DIFF
--- a/DistributedChaffinMethod/DistributedChaffinMethod.c
+++ b/DistributedChaffinMethod/DistributedChaffinMethod.c
@@ -43,6 +43,7 @@ another instance of the program.
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <curl/curl.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <fcntl.h>
@@ -125,11 +126,6 @@ another instance of the program.
 //	Number of bits allowed for each digit in integer representation of permutations
 
 #define DBITS 3
-
-//	Command-line utility that gets response from a supplied URL
-//	Current choice is curl (with options to suppress progress meter but display any errors)
-
-#define URL_UTILITY "curl --silent --show-error "
 
 //	Name of temporary file in which response from server is placed
 
@@ -1660,7 +1656,15 @@ return res;
 
 #endif
 
-//	Send a command string via URL_UTILITY to the server at SERVER_URL, putting the response in the file SERVER_RESPONSE_FILE_NAME
+//	Process response from server
+
+static size_t write_curl_data(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
+return written;
+}
+
+//	Send a command string via libcurl to the server at SERVER_URL, putting the response in the file SERVER_RESPONSE_FILE_NAME
 //
 //	Returns non-zero if an error was encountered 
 
@@ -1700,22 +1704,58 @@ if (fp==NULL)
 	};
 fclose(fp);
 
-size_t ulen = strlen(URL_UTILITY);
 size_t slen = strlen(SERVER_URL);
 size_t clen = strlen(command);
-size_t flen = strlen(SERVER_RESPONSE_FILE_NAME);
-size_t len = ulen+slen+clen+flen+10;
-char *cmd;
-CHECK_MEM( cmd = malloc(len*sizeof(char)) )
-sprintf(cmd,"%s \"%s%s\" > %s",URL_UTILITY,SERVER_URL,command,SERVER_RESPONSE_FILE_NAME);
-int res = system(cmd);
-free(cmd);
+size_t len = slen+clen;
+char *url;
+CHECK_MEM( url = malloc(len*sizeof(char)) )
+sprintf(url, "%s%s", SERVER_URL, command);
 
-//	Release local lock on server access
+CURL *curl;
+CURLcode res;
 
-releaseServerLock();
+curl_global_init(CURL_GLOBAL_ALL);
 
-return res;
+/* init the curl session */
+curl = curl_easy_init();
+
+curl_easy_setopt(curl, CURLOPT_USERAGENT, "curl/7.60.0");
+
+/* set URL to get here */
+curl_easy_setopt(curl, CURLOPT_URL, url);
+
+/* disable progress meter, set to 0L to enable and disable debug output */
+curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+
+/* send all data to this function  */
+curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data);
+
+/* open the file */
+fp = fopen(SERVER_RESPONSE_FILE_NAME, "wt");
+if (fp)
+	{
+	/* write the page body to this file handle */
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+
+	/* get it! */
+	res = curl_easy_perform(curl);
+
+	/* close the header file */
+	fclose(fp);
+	}
+else
+	{
+	printf("Error: Unable to write to server response file %s\n",SERVER_RESPONSE_FILE_NAME);
+	exit(EXIT_FAILURE);
+	}
+/* cleanup curl stuff */
+curl_easy_cleanup(curl);
+
+curl_global_cleanup();
+
+free(url);
+
+return (res != CURLE_OK) ? 1 : 0;
 }
 
 #endif

--- a/DistributedChaffinMethod/Makefile
+++ b/DistributedChaffinMethod/Makefile
@@ -1,5 +1,6 @@
 CC=gcc
 CFLAGS = -O3
+LDLIBS=-lcurl
 
 all: DistributedChaffinMethod
 

--- a/DistributedChaffinMethod/Superperm.bat
+++ b/DistributedChaffinMethod/Superperm.bat
@@ -1,0 +1,2 @@
+@echo off
+DistributedChaffinMethod team Windows

--- a/DistributedChaffinMethod/msysbuild.sh
+++ b/DistributedChaffinMethod/msysbuild.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-gcc DistributedChaffinMethod.o -lcurl -o DistributedChaffinMethod -fno-pie -no-pie

--- a/DistributedChaffinMethod/msysbuild.sh
+++ b/DistributedChaffinMethod/msysbuild.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+gcc DistributedChaffinMethod.o -lcurl -o DistributedChaffinMethod -fno-pie -no-pie


### PR DESCRIPTION
Apply @ebeeson's libcurl commit and remove getServerInstance code that called curl directly.

Add Superperm.bat to run the exe with team Windows by default.