### PR TITLE
Add script that implements curl for Windows users

### DIFF
--- a/DistributedChaffinMethod/Debugging/curl.cmd
+++ b/DistributedChaffinMethod/Debugging/curl.cmd
@@ -1,5 +1,5 @@
 :: Simple wrapper that works like curl for windows users
 :: Note that it is fragile - it assumes the URL is in the third
 :: parameter and ignores the rest. This works with how URL_UTILITY
-:: is currently designed.
+:: is currently defined.
 @powershell -Command "(new-object net.webclient).DownloadString(\"%3\"")"

--- a/DistributedChaffinMethod/Debugging/curl.cmd
+++ b/DistributedChaffinMethod/Debugging/curl.cmd
@@ -2,4 +2,4 @@
 :: Note that it is fragile - it assumes the URL is in the third
 :: parameter and ignores the rest. This works with how URL_UTILITY
 :: is currently defined.
-@powershell -Command "(new-object net.webclient).DownloadString(\"%3\"")"
+@powershell -Command "(new-object net.webclient).DownloadString(\"%3\"")

--- a/DistributedChaffinMethod/Debugging/curl.cmd
+++ b/DistributedChaffinMethod/Debugging/curl.cmd
@@ -1,0 +1,5 @@
+:: Simple wrapper that works like curl for windows users
+:: Note that it is fragile - it assumes the URL is in the third
+:: parameter and ignores the rest. This works with how URL_UTILITY
+:: is currently designed.
+@powershell -Command "(new-object net.webclient).DownloadString(\"%3\"")"


### PR DESCRIPTION
I'm adding it in the "Debugging" folder since the only other file in there is for Windows users anyways. This is a simple script that uses PowerShell to download the URL instead of curl.