### PR TITLE
extra compiler flags to make DistributedChaffinMethod build with older gcc

### DIFF
--- a/DistributedChaffinMethod/Makefile
+++ b/DistributedChaffinMethod/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS = -O3
+CFLAGS = -O3 -std=c99 -D_XOPEN_SOURCE
 LDLIBS = -lm
 
 all: DistributedChaffinMethod


### PR DESCRIPTION
Adds some extra flags to CFLAGS to make it build with older version of gcc.

* `-std=c99` tells the compiler to expect C99 code;
* `-D_XOPEN_SOURCE` is required to make signal handling work.

See my message <20190514115537.GA15698@bytemark.barnyard.co.uk> on the mailing list for more details.