### PR TITLE
Change location of OpenCL headers in Linux

### DIFF
--- a/FastDCMTest/FastDCMTest.c
+++ b/FastDCMTest/FastDCMTest.c
@@ -14,7 +14,11 @@
 #include <string.h>
 #include <inttypes.h>
 #include <errno.h>
+#ifdef __linux__
+#include <CL/opencl.h>
+#else
 #include <OpenCL/opencl.h>
+#endif
 
 #include "Headers/NInfo.h"
 #include "Headers/Structures.h"


### PR DESCRIPTION
The OpenCL headers on my system (Ubuntu 18.04) are at `/usr/include/CL`, not `/usr/include/OpenCL`. This PR adds an `#ifdef` to look in that location on Linux.